### PR TITLE
Eedeleon/string experiment

### DIFF
--- a/mlflow/store/abstract_store.py
+++ b/mlflow/store/abstract_store.py
@@ -38,7 +38,7 @@ class AbstractStore:
         :param name: Desired name for an experiment
         :param artifact_location: Base location for artifacts in runs. May be None.
 
-        :return: experiment_id (integer) for the newly created experiment if successful, else None.
+        :return: experiment_id (string) for the newly created experiment if successful, else None.
         """
         pass
 
@@ -76,7 +76,7 @@ class AbstractStore:
         Delete the experiment from the backend store. Deleted experiments can be restored until
         permanently deleted.
 
-        :param experiment_id: Integer id for the experiment
+        :param experiment_id: String id for the experiment
         """
         pass
 
@@ -85,7 +85,7 @@ class AbstractStore:
         """
         Restore deleted experiment unless it is permanently deleted.
 
-        :param experiment_id: Integer id for the experiment
+        :param experiment_id: String id for the experiment
         """
         pass
 
@@ -94,7 +94,7 @@ class AbstractStore:
         """
         Update an experiment's name. The new name must be unique.
 
-        :param experiment_id: Integer id for the experiment
+        :param experiment_id: String id for the experiment
         """
         pass
 

--- a/mlflow/store/dbmodels/models.py
+++ b/mlflow/store/dbmodels/models.py
@@ -60,6 +60,9 @@ def _create_entity(base, model):
                 elif k == "status":
                     obj = RunStatus.from_string(obj)
 
+        if isinstance(model, SqlExperiment) and k == "experiment_id":
+            obj = str(obj)
+
         config[k] = obj
     return base(**config)
 

--- a/mlflow/store/sqlalchemy_store.py
+++ b/mlflow/store/sqlalchemy_store.py
@@ -184,7 +184,7 @@ class SqlAlchemyStore(AbstractStore):
                 raise MlflowException('Experiment(name={}) already exists. '
                                       'Error: {}'.format(name, str(e)), RESOURCE_ALREADY_EXISTS)
 
-            return experiment.experiment_id
+            return str(experiment.experiment_id)
 
     def _list_experiments(self, session, ids=None, names=None, view_type=ViewType.ACTIVE_ONLY):
         stages = LifecycleStage.view_type_to_stages(view_type)

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -103,7 +103,6 @@ def start_run(run_uuid=None, experiment_id=None, source_name=None, source_versio
              the run's state.
     """
     global _active_run_stack
-    experiment_id = experiment_id if experiment_id is not None else None
     # back compat for int experiment_id
     experiment_id = str(experiment_id) if isinstance(experiment_id, int) else experiment_id
     if len(_active_run_stack) > 0 and not nested:

--- a/mlflow/utils/proto_json_utils.py
+++ b/mlflow/utils/proto_json_utils.py
@@ -6,34 +6,25 @@ def message_to_json(message):
     return MessageToJson(message, preserving_proto_field_name=True)
 
 
-def patch_experiment_id(js_dict):
-    experiment_id_key = "experiment_id"
-    if experiment_id_key in js_dict and isinstance(js_dict[experiment_id_key], int):
-        js_dict[experiment_id_key] = str(js_dict[experiment_id_key])
-
-
-def patch_experiment_ids(js_dict):
-    experiment_ids_key = "experiment_ids"
-    if experiment_ids_key in js_dict and isinstance(js_dict[experiment_ids_key], list):
-        js_dict[experiment_ids_key] = [str(val) for val in js_dict[experiment_ids_key]]
-
-
-def backcompat_helper(js_dict):
-    #  Update int experiment_id from old servers to string
-    for key in js_dict:
-        patch_experiment_id(js_dict)
-        patch_experiment_ids(js_dict)
-        if isinstance(js_dict[key], list):
-            for child in js_dict[key]:
-                if isinstance([child], dict):
-                    patch_experiment_id([child])
-                    patch_experiment_ids([child])
-        elif isinstance(js_dict[key], dict):
-            patch_experiment_id(js_dict[key])
-            patch_experiment_ids(js_dict[key])
+def _stringify_all_experiment_ids(x):
+    if isinstance(x, dict):
+        items = x.items()
+        for k, v in items:
+            if k == "experiment_id":
+                x[k] = str(v)
+            elif k == "experiment_ids":
+                x[k] = [str(w) for w in v]
+            elif k == "info" and isinstance(v, dict) and "experiment_id" in v and "run_uuid" in v:
+                # shortcut for run info
+                v["experiment_id"] = str(v["experiment_id"])
+            elif k not in ("params", "tags", "metrics"):  # skip run data
+                _stringify_all_experiment_ids(v)
+    elif isinstance(x, list):
+        for y in x:
+            _stringify_all_experiment_ids(y)
 
 
 def parse_dict(js_dict, message):
-    """Parses a JSON dictionary into a message proto, ignoring unknown fields in the JOSN."""
-    backcompat_helper(js_dict)
+    """Parses a JSON dictionary into a message proto, ignoring unknown fields in the JSON."""
+    _stringify_all_experiment_ids(js_dict)
     ParseDict(js_dict=js_dict, message=message, ignore_unknown_fields=True)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,3 @@
-#from mlflow.utils.logging_utils import _configure_mlflow_loggers
+from mlflow.utils.logging_utils import _configure_mlflow_loggers
 
-#_configure_mlflow_loggers(root_module_name=__name__)
+_configure_mlflow_loggers(root_module_name=__name__)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,3 @@
-from mlflow.utils.logging_utils import _configure_mlflow_loggers
+#from mlflow.utils.logging_utils import _configure_mlflow_loggers
 
-_configure_mlflow_loggers(root_module_name=__name__)
+#_configure_mlflow_loggers(root_module_name=__name__)

--- a/tests/store/test_sqlalchemy_store.py
+++ b/tests/store/test_sqlalchemy_store.py
@@ -65,7 +65,7 @@ class TestSqlAlchemyStoreSqliteInMemory(unittest.TestCase):
         self.assertEqual(len(experiments), 1)
 
         first = experiments[0]
-        self.assertEqual(first.experiment_id, 0)
+        self.assertEqual(first.experiment_id, "0")
         self.assertEqual(first.name, "Default")
 
     def test_default_experiment_lifecycle(self):
@@ -156,7 +156,7 @@ class TestSqlAlchemyStoreSqliteInMemory(unittest.TestCase):
                 res = session.query(models.SqlExperiment).filter_by(
                     experiment_id=experiment_id).first()
                 self.assertIn(res.name, testnames)
-                self.assertEqual(res.experiment_id, experiment_id)
+                self.assertEqual(str(res.experiment_id), experiment_id)
 
     def test_create_experiments(self):
         with self.store.ManagedSessionMaker() as session:
@@ -170,7 +170,7 @@ class TestSqlAlchemyStoreSqliteInMemory(unittest.TestCase):
             self.assertEqual(len(result), 2)
 
             test_exp = session.query(models.SqlExperiment).filter_by(name='test exp').first()
-            self.assertEqual(test_exp.experiment_id, experiment_id)
+            self.assertEqual(str(test_exp.experiment_id), experiment_id)
             self.assertEqual(test_exp.name, 'test exp')
 
         actual = self.store.get_experiment(experiment_id)

--- a/tests/utils/test_backwards_compatibility.py
+++ b/tests/utils/test_backwards_compatibility.py
@@ -1,0 +1,108 @@
+import os
+import re
+import subprocess
+import time
+
+import mlflow
+import mlflow.tracking
+from mlflow.utils.environment import _mlflow_conda_env
+from mlflow.utils.file_utils import TempDir
+from mlflow.projects import _get_conda_bin_executable
+
+
+# Test backwards compatibility with the latest mlflow release.
+# Old client should work with new server and vice versa.
+def test_backwards_compatibility():
+    # create conda env
+    _mlflow_conda_env(
+        path="mlflow_latest_released.yml",
+        additional_pip_deps=["mlflow"]
+    )
+    assert 0 == os.system("conda env create -n mlflow_release -f mlflow_latest_released.yml")
+    pattern = re.compile(".*Listening at\: (http\://127.0.0.1:[0-9]+).*")
+    activate_conda_cmd = "source {activate} mlflow_release &&".format(
+        activate=_get_conda_bin_executable("activate"))
+    try:
+        for conf in ("old server", "old client"):
+            with TempDir(chdr=True):
+                print("TESTING", conf)
+                activate_server_env = activate_conda_cmd if conf == "old server" else ""
+                server = subprocess.Popen(
+                    ["bash", "-c", activate_server_env + "mlflow server -w 1 --port 0"],
+                    stdout=subprocess.PIPE,
+                    stdin=subprocess.PIPE, stderr=subprocess.PIPE,
+                    universal_newlines=True
+                )
+                try:
+                    m = False
+                    while not m:
+                        time.sleep(1)
+                        l = server.stderr.readline()
+                        m = pattern.match(l)
+                    url = m.group(1)
+                    print("started mlflow server listening at ", url)
+                    activate_client_env = activate_conda_cmd if conf == "old client" else ""
+                    start_client_cmd = "MLFLOW_TRACKING_URI={url} python {src}".format(
+                        url=url, src=__file__)
+                    client = subprocess.Popen(
+                        ["bash", "-c", activate_client_env + start_client_cmd],
+                        stdout=subprocess.PIPE,
+                        stdin=subprocess.PIPE, stderr=subprocess.PIPE,
+                        universal_newlines=True
+                    )
+                    (stdout, stderr) = client.communicate(None)
+                    print("STDOUT")
+                    print(stdout)
+                    print("STDERR")
+                    print(stderr)
+                    assert client.returncode == 0
+                    mlflow.set_tracking_uri(url)
+                    client = mlflow.tracking.MlflowClient()
+                    assert len(client.list_experiments()) == 3
+
+                finally:
+                    server.kill()
+    finally:
+        # pass
+        os.system("conda env remove -y -n mlflow_release")
+
+
+if __name__ == '__main__':
+    assert mlflow.get_tracking_uri().startswith("http://")
+    from mlflow.version import VERSION
+    print("mlflow version = " + VERSION)
+    print("TRACKING URI = " + mlflow.get_tracking_uri())
+    id1 = mlflow.create_experiment("test_experiment_1")
+    mlflow.set_experiment("test_experiment_1")
+
+    with mlflow.start_run():
+        mlflow.log_param("a", "b")
+        mlflow.log_metric("m", 1)
+
+    id2 = mlflow.create_experiment("test_experiment_2")
+    mlflow.set_experiment("test_experiment_2")
+    with mlflow.start_run():
+        mlflow.log_param("c", "d")
+        mlflow.log_metric("m", 2)
+        mlflow.set_tag("x", "y")
+
+    with mlflow.start_run():
+        mlflow.log_param("e", "f")
+        mlflow.log_metric("m", 3)
+
+    client = mlflow.tracking.MlflowClient()
+    print(client.list_experiments())
+    print("deleting experiment", id1, type(id1))
+    client.delete_experiment(id1)
+    print("deleting experiment", id2, type(id2))
+    client.delete_experiment(id2)
+    assert len(client.list_experiments()) == 1
+    client.restore_experiment(id1)
+    client.restore_experiment(id2)
+    assert len(client.list_experiments()) == 3
+    assert len(client.list_run_infos(experiment_id=id1)) == 1
+    assert len(client.list_run_infos(experiment_id=id2)) == 2
+    print(client.list_run_infos(experiment_id=id1))
+    print(client.list_run_infos(experiment_id=id2))
+
+

--- a/tests/utils/test_proto_json_utils.py
+++ b/tests/utils/test_proto_json_utils.py
@@ -5,7 +5,7 @@ from mlflow.entities import Experiment, Metric
 from mlflow.protos.service_pb2 import Experiment as ProtoExperiment
 from mlflow.protos.service_pb2 import Metric as ProtoMetric
 
-from mlflow.utils.proto_json_utils import message_to_json, parse_dict, backcompat_helper
+from mlflow.utils.proto_json_utils import message_to_json, parse_dict, _stringify_all_experiment_ids
 
 
 def test_message_to_json():
@@ -53,49 +53,13 @@ def test_back_compat():
                "experiment_ids": [1, 2, 3, 4, 5],
                "things": {"experiment_id": 4,
                           "more_things": {"experiment_id": 7, "experiment_ids": [2, 3, 4, 5]}}}
-    verify_experiment_id_types(in_json, int)
-    backcompat_helper(in_json)
-    verify_experiment_id_types(in_json, str)
 
-
-def test_verify_experiment_id_type():
-    in_json = {"experiment_id": 123,
-               "name": "name",
-               "unknown": "field",
-               "experiment_ids": [1, 2, 3, 4, 5],
-               "things": [{"experiment_id": 4, "experiment_ids": ["2", 3, 4, 5]},
-                          {"experiment_id": 5, "experiment_ids": ["2", 3, 4, 5]}]}
-    with pytest.raises(AssertionError):
-        verify_experiment_id_types(in_json, int)
-    with pytest.raises(AssertionError):
-        verify_experiment_id_types(in_json, str)
-
-    valid_int_json = {"experiment_id": 123,
-                      "name": "name",
-                      "unknown": "field",
-                      "experiment_ids": [1, 2, 3, 4, 5],
-                      "things": [{"experiment_id": 4, "experiment_ids": [2, 3, 4, 5]},
-                                 {"experiment_id": 5, "experiment_ids": [2, 3, 4, 5]}]}
-    with pytest.raises(AssertionError):
-        verify_experiment_id_types(valid_int_json, str)
-    verify_experiment_id_types(valid_int_json, int)
-
-
-def check_known_keys(js_dict, expected_type):
-    if "experiment_id" in js_dict:
-        assert type(js_dict["experiment_id"]) == expected_type
-
-    if "experiment_ids" in js_dict:
-        for val in js_dict["experiment_ids"]:
-            assert type(val) == expected_type
-
-
-def verify_experiment_id_types(js_dict, expected_type):
-    check_known_keys(js_dict, expected_type)
-    for key in js_dict:
-        if isinstance(js_dict[key], list):
-            for val in js_dict[key]:
-                if isinstance(val, dict):
-                    check_known_keys(val, expected_type)
-        elif isinstance(js_dict[key], dict):
-            check_known_keys(js_dict[key], expected_type)
+    _stringify_all_experiment_ids(in_json)
+    exp_json = {"experiment_id": "123",
+                "name": "name",
+                "unknown": "field",
+                "experiment_ids": ["1", "2", "3", "4", "5"],
+                "things": {"experiment_id": "4",
+                           "more_things": {"experiment_id": "7",
+                                           "experiment_ids": ["2", "3", "4", "5"]}}}
+    assert exp_json == in_json


### PR DESCRIPTION
Hi Eddie. Since we do not have much time I have created the following PR to address some of my comments. Please take a look and see if you want to merge it into your branch.

It's only minor changes:

1. updated abstract store experiment_id to string (just docs)
2. updated SqlAlchemy experiment id to string, updated test
3. cleaned up the stringification a bit- there appeared to be a bug with extra []. The test seemed to be buggy as well. 
4. I have added a backwards compatibility test. This test should test combination new client / old server and old client / new server talking over rest api. However, the test is passing for me even when I comment out the stringification code. That's in both python 2 and python3. I don't know if I did something wrong.

